### PR TITLE
Added rustls-tls feature export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ async-trait = "0.1"
 digest_auth = "0.3"
 reqwest = { version = "0.11", default-features = false }
 
-# is this really needed?
-# [target.'cfg(blocking)'.dependencies]
-# reqwest =  { version = "0.11", features = ["blocking"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,18 @@ license = "MIT"
 repository = "https://github.com/maoertel/diqwest"
 
 [features]
-default = []
+default = ["reqwest/default"]
 blocking = ["reqwest/blocking"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1"
 digest_auth = "0.3"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false }
 
-[target.'cfg(blocking)'.dependencies]
-reqwest =  { version = "0.11", features = ["blocking"] }
+# is this really needed?
+# [target.'cfg(blocking)'.dependencies]
+# reqwest =  { version = "0.11", features = ["blocking"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
In our use case, we prefer rustls-tls in order to be able to easily cross-compile to targets using static compilation (musl)

This could be useful for other users