### PR TITLE
Less dependencies by `default`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ license = "MIT"
 repository = "https://github.com/maoertel/diqwest"
 
 [features]
-default = ["reqwest/default"]
+default = []
 blocking = ["reqwest/blocking"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1"
-digest_auth = "0.3"
+digest_auth = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false }
 url = "2.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/maoertel/diqwest"
 [features]
 default = []
 blocking = ["reqwest/blocking"]
-rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
Dedicated `rsut-tls` feature is not needed, when default features are disabled anyway. Just decide in your application which TLS to use.