### PR TITLE
Remove `async-trait`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ default = []
 blocking = ["reqwest/blocking"]
 
 [dependencies]
-async-trait = "0.1"
 digest_auth = { version = "0.3", default-features = false }
 reqwest = { version = "0.12", default-features = false }
 url = "2.4"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ When you send a request with digest auth flow this first request will be execute
 
 In case the first response is not a `401` this first response is returned from `send_with_digest_auth()` without any manipulation. In case the first response is a `401` but the `www-authenticate` header is missing the first reponse is returned as well.
 
+`diqwest` is a lean crate and has nearly no dependencies:
+- `reqwest`, for sure, as `diqwest` is an extension to it. Without any enabled features and no default features.
+- `digest_auth` is used to calculate the answer. Without any enabled feature and no default features.
+- `url` is used to parse parse a url on type level. Without any enabled feature and no default features.
+
+That's it. No other dependencies are used. Not even `thiserror` is used to not force it on you.
+
 ## Examples
 
 ### Async (default)

--- a/src/common.rs
+++ b/src/common.rs
@@ -26,6 +26,7 @@ where
   fn body(&self) -> Option<&B>;
 }
 
+#[allow(dead_code)]
 pub(crate) trait WithHeaders {
   fn headers(&self) -> &HeaderMap;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ pub mod blocking;
 pub mod common;
 pub mod error;
 
-use async_trait::async_trait;
+use std::future::Future;
+
 use digest_auth::AuthContext;
 use reqwest::header::{HeaderMap, AUTHORIZATION};
 use reqwest::{Body, Method};
@@ -57,12 +58,10 @@ use crate::error::{Error, Result};
 /// A trait to extend the functionality of an async `RequestBuilder` to send a request with digest auth flow.
 ///
 /// Call it at the end of your `RequestBuilder` chain like you would use `send()`.
-#[async_trait]
 pub trait WithDigestAuth {
-  async fn send_with_digest_auth(&self, username: &str, password: &str) -> Result<Response>;
+  fn send_with_digest_auth(&self, username: &str, password: &str) -> impl Future<Output = Result<Response>> + Send;
 }
 
-#[async_trait]
 impl WithDigestAuth for RequestBuilder {
   async fn send_with_digest_auth(&self, username: &str, password: &str) -> Result<Response> {
     let first_response = self.refresh()?.send().await?;


### PR DESCRIPTION
Get rid of `async-trait` now that async functions are supported natively.