### PR TITLE
Updating the authorization header instead of adding another

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,13 @@ async fn try_digest_auth(
   password: &str,
 ) -> Result<Response> {
   if let Some(answer) = get_answer(request_builder, first_response.headers(), username, password)? {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, answer.to_header_string().parse().unwrap());
+    
     return Ok(
       request_builder
         .refresh()?
-        .header(AUTHORIZATION, answer.to_header_string())
+        .headers(headers)
         .send()
         .await?,
     );


### PR DESCRIPTION
The reqwest `header` function appends another Authorization header. 

Even though reqwest does not have any method to remove a header from a `RequestBuilder`, we can override it by using the `headers` function.

This solves the issue https://github.com/maoertel/diqwest/issues/7 that was closed without a solution though.

Now, we can do the following:
```rust
client.get(&connection_url)
        .basic_auth(&username, Some(&password))
        .send_with_digest_auth(&username, &password)
        .await
```
It will send the first request with basic auth and then will try digest.