### PR TITLE
Update dependencies: reqwest 0.13, url 2.5, mockito 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 out/
 .DS_Store
 Cargo.lock
+CLAUDE.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ blocking = ["reqwest/blocking"]
 
 [dependencies]
 digest_auth = { version = "0.3", default-features = false }
-reqwest = { version = "0.12", default-features = false }
-url = "2.4"
+reqwest = { version = "0.13", default-features = false }
+url = "2.5"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-mockito = "1.4"
+mockito = "1.7"


### PR DESCRIPTION
## Summary
- Upgrade reqwest from 0.12 to 0.13
- Upgrade url from 2.4 to 2.5
- Upgrade mockito from 1.4 to 1.7 (dev dependency)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --all-features` passes (all 6 tests)