### PR TITLE
Replace authorization header instead of appending

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -30,13 +30,16 @@ fn try_digest_auth(
   password: &str,
 ) -> Result<Response> {
   if let Some(answer) = get_answer(request_builder, first_response.headers(), username, password)? {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, answer.to_header_string().parse()?);
+
     return Ok(
       request_builder
         .refresh()?
-        .header(AUTHORIZATION, answer.to_header_string())
+        .headers(headers)
         .send()?,
     );
-  };
+  }
 
   Ok(first_response)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,14 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::result;
 
-use reqwest::header::ToStrError;
+use reqwest::header::{InvalidHeaderValue, ToStrError};
 
 #[derive(Debug)]
 pub enum Error {
   Reqwest(reqwest::Error),
   DigestAuth(digest_auth::Error),
   ToStr(reqwest::header::ToStrError),
+  InvalidHeaderValue(reqwest::header::InvalidHeaderValue),
   AuthHeaderMissing,
   RequestBuilderNotCloneable,
 }
@@ -20,6 +21,7 @@ impl Display for Error {
       Error::Reqwest(e) => std::fmt::Display::fmt(e, f),
       Error::DigestAuth(e) => std::fmt::Display::fmt(e, f),
       Error::ToStr(e) => std::fmt::Display::fmt(e, f),
+      Error::InvalidHeaderValue(e) => std::fmt::Display::fmt(e, f),
       Error::RequestBuilderNotCloneable => write!(f, "Request body must not be a stream."),
       Error::AuthHeaderMissing => write!(f, "The header 'www-authenticate' is missing."),
     }
@@ -43,5 +45,11 @@ impl From<digest_auth::Error> for Error {
 impl From<reqwest::header::ToStrError> for Error {
   fn from(e: ToStrError) -> Self {
     Error::ToStr(e)
+  }
+}
+
+impl From<reqwest::header::InvalidHeaderValue> for Error {
+  fn from(e: InvalidHeaderValue) -> Self {
+    Error::InvalidHeaderValue(e)
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,13 @@ async fn try_digest_auth(
   password: &str,
 ) -> Result<Response> {
   if let Some(answer) = get_answer(request_builder, first_response.headers(), username, password)? {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, answer.to_header_string().parse().unwrap());
+    
     return Ok(
       request_builder
         .refresh()?
-        .header(AUTHORIZATION, answer.to_header_string())
+        .headers(headers)
         .send()
         .await?,
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ async fn try_digest_auth(
 ) -> Result<Response> {
   if let Some(answer) = get_answer(request_builder, first_response.headers(), username, password)? {
     let mut headers = HeaderMap::new();
-    headers.insert(AUTHORIZATION, answer.to_header_string().parse().unwrap());
-    
+    headers.insert(AUTHORIZATION, answer.to_header_string().parse()?);
+
     return Ok(
       request_builder
         .refresh()?
@@ -96,7 +96,7 @@ async fn try_digest_auth(
         .send()
         .await?,
     );
-  };
+  }
 
   Ok(first_response)
 }


### PR DESCRIPTION
## Summary

When retrying a request with digest authentication, the existing `Authorization` header (if any) is now replaced rather than having a duplicate appended. This prevents sending requests with multiple `Authorization` headers.

- Use `.headers()` instead of `.header()` to replace existing Authorization header
- Add `InvalidHeaderValue` error variant for proper error propagation instead of panicking
- Apply fix to both async and blocking implementations

Supersedes #23 with proper error handling.

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-features` passes