### PR TITLE
Update to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diqwest"
 version = "3.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 description = "Trait to extend reqwest for digest auth flow."
 documentation = "https://docs.rs/diqwest"


### PR DESCRIPTION
## Summary
Update Rust edition from 2021 to 2024.

## Test plan
- [x] `cargo build --all-features` passes
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-features` passes