### PR TITLE
Prepare v3.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diqwest"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 description = "Trait to extend reqwest for digest auth flow."

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -33,7 +33,7 @@ pub trait WithDigestAuth {
   fn send_digest_auth<C: DigestAuthCredentials>(&self, credentials: C) -> Result<Response>;
 
   /// Sends the request with digest authentication.
-  #[deprecated(since = "4.0.0", note = "Use send_digest_auth instead")]
+  #[deprecated(since = "3.2.0", note = "Use send_digest_auth instead. Will be removed in 4.0.0.")]
   fn send_with_digest_auth(&self, username: &str, password: &str) -> Result<Response>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub trait WithDigestAuth {
   ) -> impl Future<Output = Result<Response>> + Send;
 
   /// Sends the request with digest authentication.
-  #[deprecated(since = "4.0.0", note = "Use send_digest_auth instead")]
+  #[deprecated(since = "3.2.0", note = "Use send_digest_auth instead. Will be removed in 4.0.0.")]
   fn send_with_digest_auth(&self, username: &str, password: &str) -> impl Future<Output = Result<Response>> + Send;
 }
 


### PR DESCRIPTION
## Summary
- Bump version to 3.2.0
- Update deprecation hints for `send_with_digest_auth`:
  - `since`: 4.0.0 → 3.2.0
  - Added note: "Will be removed in 4.0.0."